### PR TITLE
[feat] 카카오 로그인 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import Write from './pages/Notice/Write/Write.jsx';
 import NoticeRoomEntry from './pages/Auth/NoticeRoomEntry.jsx';
 import ConfirmRequestApproval from './pages/Notice/Confirm/ConfirmRequestApproval.jsx';
 import Layout from './components/layout/index.jsx';
+import Redirect from './pages/Auth/Redirect.jsx';
 
 function App() {
   return (
@@ -41,6 +42,7 @@ function App() {
             <Route path="/" element={<Layout />}>
               {/* Auth - 로그인&회원가입 */}
               <Route path="/" element={<SignIn />} />
+              <Route path="/redirect" element={<Redirect />} />
               <Route path="/sign-up" element={<SignUp />} />
 
               {/* Home - 메인 */}

--- a/src/assets/svgs/kakao_logo.svg
+++ b/src/assets/svgs/kakao_logo.svg
@@ -1,0 +1,10 @@
+<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3380_9354)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.00002 1.1001C4.02917 1.1001 0 4.21306 0 8.05238C0 10.4401 1.5584 12.5451 3.93152 13.7971L2.93303 17.4446C2.84481 17.7669 3.21341 18.0238 3.49646 17.837L7.87334 14.9483C8.2427 14.9839 8.61808 15.0047 9.00002 15.0047C13.9705 15.0047 17.9999 11.8919 17.9999 8.05238C17.9999 4.21306 13.9705 1.1001 9.00002 1.1001Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_3380_9354">
+<rect width="17.9999" height="18" fill="white" transform="translate(0 0.5)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/pages/Auth/Redirect.jsx
+++ b/src/pages/Auth/Redirect.jsx
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const Redirect = () => {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const code = params.get('code');
+  const baseUrl = import.meta.env.VITE_BASE_URL;
+
+  useEffect(() => {
+    (async () => {
+      const response = await axios.post(
+        `${baseUrl}/user/login/kakao?code=${code}`,
+      );
+      localStorage.setItem('token', response.data.result.accessToken);
+      navigate('/home');
+    })();
+  }, []);
+  return <div>Redirecting...</div>;
+};
+
+export default Redirect;

--- a/src/pages/Auth/SignIn.jsx
+++ b/src/pages/Auth/SignIn.jsx
@@ -1,16 +1,21 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import CustomInput from '../../components/CustomInput.jsx';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { login } from '../../api/Auth/user.js';
 import logo from '../../assets/svgs/logoex.svg';
+import { ReactComponent as KakaoLogo } from '../../assets/svgs/kakao_logo.svg';
 
 const SignIn = () => {
   const navigate = useNavigate();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+
+  const apiKey = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+  const kakaoLoginPage = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${apiKey}&redirect_uri=${redirectUri}&response_type=code`;
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -44,6 +49,10 @@ const SignIn = () => {
           charCount={true}
         />
         <ButtonWrapper>
+          <KakaoLogin to={kakaoLoginPage} className="medium-16">
+            <KakaoLogo />
+            카카오톡으로 계속하기
+          </KakaoLogin>
           <SignInButton onClick={handleLogin}>로그인</SignInButton>
           <NotAuth>아직 회원이 아니신가요?</NotAuth>
           <SignupButton onClick={() => navigate('/sign-up')}>
@@ -77,8 +86,20 @@ const CommonButton = styled.button`
   width: calc(100% - 2rem);
 `;
 
+const KakaoLogin = styled(Link)`
+  text-decoration: none;
+  color: rgba(0, 0, 0, 0.85);
+  padding: 1rem 0;
+  border-radius: 0.5rem;
+  width: calc(100% - 2rem);
+  background-color: #fee500;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+`;
+
 const SignInButton = styled(CommonButton)`
-  margin-bottom: 0.625rem;
+  margin: 0.625rem 0;
   background-color: #509bf7;
   color: #ffffff;
 `;


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 카카오 로그인 구현 #114 

닫을 이슈 번호: resolved #114

## 📌 반영 브랜치

> feat/#114 -> dev

## 📋 내용

> 카카오 로그인 구현했습니다.

### 🖼️ 스크린샷 (선택)

> 카카오 로그인 버튼 추가된 모습
<img width="1552" alt="스크린샷 2024-08-15 오후 3 46 50" src="https://github.com/user-attachments/assets/ebaebb1d-a89c-4984-8840-3a9427a26754">

> 카카오 로그인을 한 모습
<img width="1552" alt="스크린샷 2024-08-15 오후 3 47 17" src="https://github.com/user-attachments/assets/9c716087-fbcc-4dbb-9434-917a117f5414">

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
