### PR TITLE
[Fix] 공지방 메인 사진 안나오는 오류 수정

### DIFF
--- a/src/components/Notice/NoticePreview.jsx
+++ b/src/components/Notice/NoticePreview.jsx
@@ -23,9 +23,7 @@ export const NoticePreview = ({
       <StyledLink to={`/notice/${roomId}/${props.postId}`}>
         <BottomContainer>
           <NoticeContent>{props.postBody}</NoticeContent>
-          {props.postImage && (
-            <Thumbnail src="/src/assets/pngs/defaultprofileimage.png" />
-          )}
+          {props.postImage && <Thumbnail src={props.postImage} />}
         </BottomContainer>
       </StyledLink>
       {btnText && (


### PR DESCRIPTION
# 🚩 관련 이슈

> [Fix] 공지방 메인 사진 안나오는 오류 수정 #178 

닫을 이슈 번호: resolved #178 

## 📌 반영 브랜치

> ex) feat-178 -> dev

## 📋 내용

> 공지방 메인 프리뷰 사진 안나오는 오류 수정

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 없음
