### PR TITLE
[style] 메인 페이지 입장한 공지방, 개설한 공지방 grid 스타일 구현

### DIFF
--- a/src/components/Main/EnteredNoticeRoom.jsx
+++ b/src/components/Main/EnteredNoticeRoom.jsx
@@ -129,13 +129,10 @@ const EnteredNoticeRoomSection = styled.section`
 `;
 
 const NoticeRooms = styled.div`
-  display: flex;
-  align-items: flex-start;
-  align-content: flex-start;
-  gap: 0.8125rem;
-  align-self: stretch;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 0.8125rem;
 `;
 
 const NoNoticesBox = styled.div`

--- a/src/components/Main/NoticeRoom.jsx
+++ b/src/components/Main/NoticeRoom.jsx
@@ -21,7 +21,7 @@ const NoticeRoom = ({ room, onClick }) => {
 
 const Container = styled.div`
   display: flex;
-  width: 30.5%;
+  width: 100%;
   flex-direction: column;
   align-items: flex-start;
   border-radius: 0.5rem;

--- a/src/components/Main/OpendNoticeRoom.jsx
+++ b/src/components/Main/OpendNoticeRoom.jsx
@@ -101,6 +101,7 @@ const TitleContainer = styled.div`
 `;
 
 const NoticeRoomsInfo = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -130,13 +131,10 @@ const OpenedNoticeRoomSection = styled.section`
 `;
 
 const NoticeRooms = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.8125rem;
-  align-items: flex-start;
-  align-content: flex-start;
-  align-self: stretch;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 0.8125rem;
 `;
 
 const AddButtonImage = styled.img`
@@ -146,6 +144,7 @@ const AddButtonImage = styled.img`
 `;
 
 const Pagination = styled.div`
+  width: 100%;
   display: flex;
   padding: 0.5rem 0; /* 8px */
   justify-content: center;


### PR DESCRIPTION
# 🚩 관련 이슈

> [style] 메인 페이지 입장한 공지방, 개설한 공지방 grid 스타일 구현 #183

닫을 이슈 번호: resolved #183

## 📌 반영 브랜치

> style/#183 -> dev

## 📋 내용

> display: flex -> grid

### 🖼️ 스크린샷 (선택)

> 
<img width="430" alt="스크린샷 2024-08-20 오후 6 07 22" src="https://github.com/user-attachments/assets/44729b81-3600-423f-9864-70c454740d70">


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
