### PR TITLE
Fix: 미확인 인원 목록 기본 프로필 이미지 처리 수정

### DIFF
--- a/src/components/Notice/NoticeTitle/UnconfirmedPeopleItem.jsx
+++ b/src/components/Notice/NoticeTitle/UnconfirmedPeopleItem.jsx
@@ -2,13 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 
 export const UnconfirmedPeopleItem = ({ props }) => {
+  console.log(props);
   return (
     <Container>
-      {props.profile_image !== null ? (
-        <Thumbnail src="/src/assets/pngs/defaultprofileimage.png" />
-      ) : (
-        <Thumbnail src={props.profile_image} />
-      )}
+      {props.profile_image && <Thumbnail src={props.profile_image} />}
       <UserName>{props.nickname}</UserName>
     </Container>
   );
@@ -43,11 +40,8 @@ const UserName = styled.div`
   overflow: hidden;
   color: var(--Text-default, var(--Grayscale-Gray7, #222));
   text-overflow: ellipsis;
-  /* Pretendard/regular/16 */
-  font-family: Pretendard;
   font-size: 1rem;
-  font-style: normal;
   font-weight: 400;
-  line-height: 100%; /* 1rem */
+  line-height: 100%;
   letter-spacing: -0.02rem;
 `;


### PR DESCRIPTION
# 🚩 관련 이슈

> [Fix] 미확인 유저 프로필 이미지 안보이는 오류 수정 #193 

닫을 이슈 번호: resolved #193 

## 📌 반영 브랜치

> ex) feat-193 -> dev

## 📋 내용

> 미확인 유저 프로필 이미지 안보이는 오류 수정


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 없음
