### PR TITLE
Refactor: 공지글 상세보기의 더보기에 관리자 기능 추가

### DIFF
--- a/src/components/Notice/NoticeItem.jsx
+++ b/src/components/Notice/NoticeItem.jsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import NoticeCheck from '../../assets/svgs/notice_check.svg';
 import { useNavigate, useParams } from 'react-router-dom';
 
-export const NoticeItem = ({ props, imgs, preview }) => {
+export const NoticeItem = ({ props, imgs, preview, isManager }) => {
   const navigate = useNavigate();
   const { roomId, postId } = useParams();
 
   return (
     <Container>
-      <NoticeTitle {...props} preview={preview} />
+      <NoticeTitle {...props} preview={preview} isManager={isManager} />
       <NoticeContent>{props?.postBody}</NoticeContent>
       {imgs && imgs.map((img) => <Thumbnail key={img} src={img} />)}
       {preview ? (

--- a/src/pages/Notice/Details.jsx
+++ b/src/pages/Notice/Details.jsx
@@ -84,7 +84,11 @@ const NoticeDetails = () => {
     <div className="container">
       <Header title={res.roomName} isSearch={false} onClick={handleClick} />
       <Container>
-        <NoticeItem props={res.post[0]} imgs={res.imageURLs} />
+        <NoticeItem
+          props={res.post[0]}
+          imgs={res.imageURLs}
+          isManager={res.isRoomAdmin}
+        />
 
         <CommentList>
           {comments.length > 0 ? (


### PR DESCRIPTION
# 🚩 관련 이슈

> [Refactor] 공지글 상세보기의 더보기 버튼 수정 #165 

## 📌 반영 브랜치

> refactor-165 -> dev

## 📋 내용

> 공지글 상세보기의 더보기에 관리자 기능 추가

### 🖼️ 스크린샷 (선택)

> ex) 로그인 API 요청 swagger 사진

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
