### PR TITLE
Refactor: 관리자는 공지글 제목에 제출 상태 안뜨게 수정

### DIFF
--- a/src/components/Notice/NoticeTitle.jsx
+++ b/src/components/Notice/NoticeTitle.jsx
@@ -86,7 +86,7 @@ export const NoticeTitle = (props) => {
           {props.postType && (
             <QuizFormatLabel postType={props.postType}></QuizFormatLabel>
           )}
-          {props.submitState && (
+          {props.submitState && !props.isManager && (
             <RequestStatusLabel
               requestStatus={props.submitState}
             ></RequestStatusLabel>


### PR DESCRIPTION
# 🚩 관련 이슈

> [REFACTOR] 공지글 제목의 제출 상태 뜨는 조건 수정 #201 

## 📌 반영 브랜치

> feat-201-> dev

## 📋 내용

> 관리자는 공지글 제목에 제출 상태 안뜨게 수정

### 🖼️ 스크린샷 (선택)

> ex) 로그인 API 요청 swagger 사진

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
