### PR TITLE
Fix: NoticeTitle에 roomId 전달

### DIFF
--- a/src/components/Notice/NoticeItem.jsx
+++ b/src/components/Notice/NoticeItem.jsx
@@ -21,7 +21,12 @@ export const NoticeItem = ({ props, imgs, preview, isManager, chkActive }) => {
 
   return (
     <Container>
-      <NoticeTitle {...props} preview={preview} isManager={isManager} />
+      <NoticeTitle
+        {...props}
+        preview={preview}
+        isManager={isManager}
+        roomId={roomId}
+      />
       <NoticeContent>{props?.postBody}</NoticeContent>
       {imgs && imgs.map((img) => <Thumbnail key={img} src={img} />)}
       {!preview && !isManager && (

--- a/src/pages/Notice/Main.jsx
+++ b/src/pages/Notice/Main.jsx
@@ -101,6 +101,10 @@ const Main = () => {
     }
   };
 
+  const handleClick = () => {
+    location.reload();
+  };
+
   useEffect(() => {
     const getNoticeData = async () => {
       try {
@@ -148,6 +152,7 @@ const Main = () => {
         isSearch={true}
         url="/home"
         setSearchValue={setSearchValue}
+        onClick={handleClick}
       />
       {isPenaltyModalOpen && (
         <PenaltyContainer>


### PR DESCRIPTION
# 🚩 관련 이슈

> [FIX] 공지글 상세보기에서 주소 공유 오류 수정 #228

## 📌 반영 브랜치

> ex) fix-228 -> dev

## 📋 내용

> NoticeItem에서 NoticeTitle로 roomId 전달

### 🖼️ 스크린샷 (선택)

> ex) 로그인 API 요청 swagger 사진

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
